### PR TITLE
Create build.yml to build the installer automatically

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Build Installer
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    name: Build the Inno Setup Installer
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compile .ISS to .EXE Installer
+        uses: Minionguyjpro/Inno-Setup-Action@v1.2.6
+        with:
+          path: installer/LEOinstaller.iss
+
+      - name: Rename .EXE file
+        run:
+          move installer\Output\mysetup.exe installer\Output\setup_LEO.exe
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Setup_LEO
+          path: installer/Output/setup_LEO.exe


### PR DESCRIPTION
Created and [tested](https://github.com/Miniontoby/LEO/actions/runs/19042525767) build.yml to build the installer automatically.

I thought it would be nice to have a clean installer, which might even be able to be plugged into another workflow where it will make a release for you.

For now, it will build the installer on a push to main, and then it will upload the artifact to the action run, where you can download it and upload it manually to a new release.

For questions and bugs, you can always find me ;)